### PR TITLE
CSS3Dの判定が、IE10で正常に動作しない不具合を修正。

### DIFF
--- a/src/theta-viewer.js
+++ b/src/theta-viewer.js
@@ -672,7 +672,7 @@
         if (Detector.webgl !== false) {
             // WebGLが使用可能
             mode = "WebGL";
-        } else if (Modernizr.csstransforms3d === true && Modernizr.canvas === true) {
+        } else if (Modernizr.csstransforms3d === true && Modernizr.canvas === true && Modernizr.transformstylepreserve3d === true) {
             // CSS Transforms 3Dが使用可能
             mode = "CSS3D";
         } else if (Modernizr.canvas === true) {
@@ -743,3 +743,56 @@
     };
 
 }(jQuery));
+
+Modernizr.addValueTest = function(property,value){
+	var testName= (property+value).replace(/-/g,'');
+	Modernizr.addTest(testName , function () {
+		var element = document.createElement('link');
+		var body = document.getElementsByTagName('HEAD')[0];
+		var properties = [];
+		var upcaseProp = property.replace(/(^|-)([a-z])/g, function(a, b, c){ return c.toUpperCase(); });
+		properties[property] = property;
+		properties['Webkit'+upcaseProp] ='-webkit-'+property;
+		properties['Moz'+upcaseProp] ='-moz-'+property;
+		properties['ms'+upcaseProp] ='-ms-'+property;
+
+		body.insertBefore(element, null);
+		for (var i in properties) {
+			if (element.style[i] !== undefined) {
+				element.style[i] = value;
+			}
+		}
+		//ie7,ie8 doesnt support getComputedStyle
+		//so this is the implementation
+		if(!window.getComputedStyle) {
+			window.getComputedStyle = function(el, pseudo) {
+				this.el = el;
+				this.getPropertyValue = function(prop) {
+					var re = /(\-([a-z]){1})/g;
+					if (prop == 'float') prop = 'styleFloat';
+					if (re.test(prop)) {
+						prop = prop.replace(re, function () {
+							return arguments[2].toUpperCase();
+						});
+					}
+					return el.currentStyle[prop] ? el.currentStyle[prop] : null;
+				};
+				return this;
+			};
+		}
+
+		var st = window.getComputedStyle(element, null),
+		currentValue = st.getPropertyValue("-webkit-"+property) ||
+		st.getPropertyValue("-moz-"+property) ||
+		st.getPropertyValue("-ms-"+property) ||
+		st.getPropertyValue(property);
+
+		if(currentValue!== value){
+			element.parentNode.removeChild(element);
+			return false;
+		}
+		element.parentNode.removeChild(element);
+		return true;
+	});
+}
+Modernizr.addValueTest('transform-style','preserve-3d');


### PR DESCRIPTION
たびたび申し訳ありません。

IEではCSS3のtransform-style: preserve-3d プロパティが実装されていないため、
three.jsのCSS3DRenderer がうまく表示できないのですが、
Modernizr で使用可能と判定されてしまう不具合を修正しました。

詳細は以下をご確認ください。
https://github.com/mrdoob/three.js/issues/4783
https://coderwall.com/p/qctclg
